### PR TITLE
Fix typo and Clippy stuff

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ impl Id {
     ///
     /// This API is only present for these sorts of cases, and shouldn't be used
     /// when either [`Id::new`] or [`Id::lazy`] works.
+    #[allow(clippy::declare_interior_mutable_const)]
     pub const LAZY_INITIALIZER: Self = Self(AtomicU64::new(0));
 
     /// Returns the value of this id, lazily initializing if needed.
@@ -258,7 +259,7 @@ impl Id {
         // force initialization
         let _ = self.get();
         // SAFETY: We've definitely been initialized by now, and so our value
-        // will never be written to again (or at least, it's no longer has
+        // will never be written to again (or at least, it no longer has
         // observable interior mutability).
         unsafe { &*(self as *const _ as *const u64) }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,8 @@ fn test_eq() {
 fn test_cmp() {
     use std::collections::BTreeMap;
     let ids: Vec<Id> = (0..100).map(|_| Id::lazy()).collect();
+
+    #[allow(clippy::mutable_key_type)]
     let map: BTreeMap<Id, usize> = ids
         .iter()
         .enumerate()
@@ -30,6 +32,8 @@ fn test_cmp() {
 fn test_hash() {
     use std::collections::HashMap;
     let ids: Vec<Id> = (0..100).map(|_| Id::lazy()).collect();
+
+    #[allow(clippy::mutable_key_type)]
     let map: HashMap<Id, usize> = ids
         .iter()
         .enumerate()
@@ -67,7 +71,7 @@ fn test_convert() {
     assert_eq!(v, u64::from(id.clone()));
     let vnz = id.get_nonzero();
     assert_eq!(vnz.get(), v);
-    assert_eq!(vnz, core::num::NonZeroU64::from(id.clone()));
+    assert_eq!(vnz, core::num::NonZeroU64::from(id));
     // silly, tbh
     assert_ne!(u64::from(Id::lazy()), u64::from(Id::lazy()));
 }


### PR DESCRIPTION
Congrats, I've never even seen the `mutable_key_type` lint before.

Anyway, title says it all. Noticed a typo when reading through this and my IDE found the Clippy stuff.